### PR TITLE
Document region option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Options are:
 - `key` - s3 key
 - `secret` - s3 secret key
 - `cdn` - optional CDN host, defaulting to the s3 bucket, such as `https://lakjsflkajfd.cloudfront.net`
+- `region` - optional bucket AWS region, such as `eu-west-1`, defaulting to the US Standard region
 
 ### cas.key(buffer | string, extension).then( key => )
 


### PR DESCRIPTION
Since the options are passed through to knox, it's possible to use non US Standard S3 buckets by setting the `region` option